### PR TITLE
Google Alerts redirect support

### DIFF
--- a/test.js
+++ b/test.js
@@ -49,5 +49,6 @@ it("should work", function()
 	
 	expect( parseMetaRefresh("5; url=http://domain.com/;")   ).to.deep.equal(timeoutAndUrl3);
 	expect( parseMetaRefresh("5; url=http://domain.com/; ")  ).to.deep.equal(timeoutAndUrl3);
+	expect( parseMetaRefresh("5;URL='http://domain.com/'")  ).to.deep.equal(timeoutAndUrl3);	// as see on Google Alerts
 	expect( parseMetaRefresh("5; url=http://domain.com/ ; ") ).to.deep.equal({ timeout:5, url:"http://domain.com/ ;" });
 });


### PR DESCRIPTION
Content on the page is like:

``` html
<script>window.googleJavaScriptRedirect=1</script><script>var n={navigateTo:function(b,a,d){if(b!=a&&b.google){if(b.google.r){b.google.r=0;b.location.href=d;a.location.replace("about:blank");}}else{a.location.replace(d);}}};n.navigateTo(window.parent,window,"http://www.standardmedia.co.ke/article/2000185440/speaker-justin-muturi-trashes-eacc-graft-report-on-mps");
</script><noscript><META http-equiv="refresh" content="0;URL='http://www.standardmedia.co.ke/article/2000185440/speaker-justin-muturi-trashes-eacc-graft-report-on-mps'"></noscript>
```
